### PR TITLE
DOCSP-998: Prevent sidebar overlapping main content.

### DIFF
--- a/src/sass/bem-components/main.scss
+++ b/src/sass/bem-components/main.scss
@@ -28,5 +28,6 @@ $sidebar-width: 330px;
     margin-top: $navbar-height;
     max-width: 900px; // TODO: Check with Melissa
     padding: 40px;
+    overflow-x: scroll;
   }
 }


### PR DESCRIPTION
Related PR on `mongodb/docs-tools`: [https://github.com/mongodb/docs-tools/pull/155](https://github.com/mongodb/docs-tools/pull/155)