### PR TITLE
DOCSP-1002: Hover state on cards

### DIFF
--- a/src/sass/bem-components/card.scss
+++ b/src/sass/bem-components/card.scss
@@ -11,6 +11,11 @@
   text-decoration: none;
   vertical-align: top;
   width: 378px;
+  transition: 400ms;
+
+  &:hover {
+    box-shadow: 0 10px 20px 1px $primary-shadow;
+  }
 
   &__icon {
     left: 28px;


### PR DESCRIPTION
Stage: https://docs-mongodbcom-staging.corp.mongodb.com/landing/nick/DOCSP-1002/index.html

The reference image on the ticket didn't have great resolution or specifics on box shadow implementation so take a look and see if it seems to have the right shade and distance. Transition speed matches the landing page accordions exactly, as specified in the ticket.