### PR TITLE
(DOCSP-4828): Update with k8s Operator.

### DIFF
--- a/src/html/home.html
+++ b/src/html/home.html
@@ -52,6 +52,9 @@
                 <a class="toc__link" href="https://docs.mongodb.com/compass/current/">MongoDB Compass</a>
               </li>
               <li class="toc__item">
+                <a class="toc__link" href="https://docs.mongodb.com/kubernetes-operator/stable/">MongoDB Enterprise Kubernetes Operator</a>
+              </li>
+              <li class="toc__item">
                 <a class="toc__link" href="https://docs.mongodb.com/spark-connector/current/">MongoDB Spark Connector</a>
               </li>
             </ul>
@@ -227,6 +230,22 @@
             <p class="block__body">
               MongoDB Stitch is a serverless platform that provides an HTTP API to MongoDB, integration with other services, and a declarative
               rules infrastructure which spans database and service actions.
+            </p>
+
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-4 no-left-gutter">
+          <div class="block">
+            <h3 class="block__header">Kubernetes</h3>
+
+            <h4 class="block__title">
+              <a class="block__link" href="https://docs.mongodb.com/kubernetes-operator/stable/">MongoDB Enterprise Kubernetes Operator</a>
+            </h4>
+            <p class="block__body">
+              MongoDB Enterprise Kubernetes Operator enables deployment of containerized MongoDB instances using Kubernetes.
             </p>
 
           </div>


### PR DESCRIPTION
@i80and : Can you check and see if I broke anything? It looks right. I [staged the change on the main landing page](https://docs-mongodbcom-staging.corp.mongodb.com/landing/anthonysansone/DOCSP-4828/).

@jdestefano-mongo : I am unsure if this should also go on the Tools or Cloud pages. Both are nice even 2x2 grids, etc. Maybe we can stay with just the one landing for now?