### PR TITLE
DOCSP-9010: Make /database-tools findable

### DIFF
--- a/src/html/home.html
+++ b/src/html/home.html
@@ -55,6 +55,9 @@
                 <a class="toc__link" href="https://docs.mongodb.com/compass/current/">MongoDB Compass</a>
               </li>
               <li class="toc__item">
+                <a class="toc__link" href="https://docs.mongodb.com/database-tools/">MongoDB Database Tools</a>
+              </li>
+              <li class="toc__item">
                 <a class="toc__link" href="https://docs.mongodb.com/kafka-connector/current/">MongoDB Kafka Connector</a>
               </li>
               <li class="toc__item">
@@ -290,6 +293,23 @@
             </h4>
             <p class="block__body">
               Included in MongoDB Atlas, use Data Explorer to inspect the databases and collections in a MongoDB cluster.
+            </p>
+
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-4 no-left-gutter">
+          <div class="block">
+            <h3 class="block__header">Database Tools</h3>
+
+            <h4 class="block__title">
+              <a class="block__link" href="https://docs.mongodb.com/database-tools">MongoDB Database Tools</a>
+            </h4>
+            <p class="block__body">
+              Tools for interfacing with a MongoDB cluster, such
+              as importing/exporting data.
             </p>
 
           </div>

--- a/src/html/tools.html
+++ b/src/html/tools.html
@@ -21,6 +21,10 @@
             <a class="toc__link" href="https://docs.mongodb.com/compass/current/">MongoDB Compass</a>
           </li>
           <li class="toc__item">
+            <a class="toc__link" href="https://docs.mongodb.com/database-tools/">MongoDB Database Tools</a>
+           </li>
+
+          <li class="toc__item">
             <a class="toc__link" href="https://docs.mongodb.com/kafka-connector/current/">MongoDB Kafka Connector</a>
           </li>
           <li class="toc__item">
@@ -78,6 +82,15 @@
         <p class="card__body">
           Reference guide for MongoDB Compass. Learn to use MongoDB Compass's
           graphical user interface to view and analyze data stored in MongoDB.
+        </p>
+      </a>
+
+      <a class="card" href="https://docs.mongodb.com/database-tools">
+        <span class="card__icon card__icon--document"></span>
+        <h3 class="card__title">MongoDB Database Tools</h3>
+        <p class="card__body">
+          Tools for interfacing with a MongoDB cluster, such as 
+          importing/exporting data. 
         </p>
       </a>
 
@@ -156,11 +169,10 @@
           </div>
         </div>
       </div>
-    </div>
 
       <div class="row">
 
-        <div class="col-3 no-right-gutter">
+        <div class="col-3 no-left-gutter">
           <div class="block">
             <h3 class="block__header">MongoDB Charts</h3>
             <h4 class="block__title">
@@ -184,7 +196,7 @@
           </div>
         </div>
 
-        <div class="col-3 no-left-gutter">
+        <div class="col-3 no-right-gutter">
           <div class="block">
             <h3 class="block__header">MongoDB Compass</h3>
             <h4 class="block__title">
@@ -216,26 +228,67 @@
       </div>
 
       <div class="row">
-
-        <div class="col-3 no-left-gutter">
-          <div class="block">
-            <h3 class="block__header">MongoDB Enterprise Kubernetes Operator</h3>
-            <h4 class="block__title">
-              <a class="block__link" href="https://docs.mongodb.com/kubernetes-operator/stable/installation/">Installation</a>
-            </h4>
-            <p class="block__body">Follow this tutorial to install the Kubernetes Operator.</p>
-            <h4 class="block__title">
-              <a class="block__link" href="https://docs.mongodb.com/kubernetes-operator/stable/tutorial/edit-deployment/">Configuration</a>
-            </h4>
-            <p class="block__body">Link the Kubernetes Operator to your Cloud Manager or Ops Manager Project.</p>
-            <h4 class="block__title">
-              <a class="block__link" href="https://docs.mongodb.com/kubernetes-operator/stable/deploy/">Resource Deployment</a>
-            </h4>
-            <p class="block__body">Deploy MongoDB standalone, replica set, and sharded cluster resources.</p>
+          <div class="col-3 no-left-gutter">
+            <div class="block">
+              <h3 class="block__header">MongoDB Database Tools</h3>
+              <h4 class="block__title">
+                <a class="block__link" href="https://docs.mongodb.com/database-tools/mongodump"><tt>mongodump</tt></a>
+              </h4>
+              <p class="block__body">Creates binary export of the contents of a MongoDB deployment.</p>
+              <h4 class="block__title">
+                <a class="block__link" href="https://docs.mongodb.com/database-tools/mongorestore"><tt>mongorestore</tt></a>
+              </h4>
+              <p class="block__body">Restore data from the binary dump created by <tt>mongodump</tt></p>
+              <h4 class="block__title">
+                <a class="block__link" href="https://docs.mongodb.com/database-tools/mongoimport"><tt>mongoimport</tt></a>
+              </h4>
+              <p class="block__body">Import Extended JSON, CSV, or TSV data to a MongoDB deployment.</p>
+              <h4 class="block__title">
+                <a class="block__link" href="https://docs.mongodb.com/database-tools/mongoexport"><tt>mongoexport</tt></a>
+              </h4>
+              <p class="block__body">Export data from a MongoDB deployment to Extended JSON or CSV.</p>
+              <h4 class="block__title">
+                <a class="block__link" href="https://docs.mongodb.com/database-tools/mongostat"><tt>mongostat</tt></a>
+              </h4>
+              <p class="block__body">Displays an overview of the status of a <tt>mongod</tt> or <tt>mongos</tt> instance.</p>
+              <h4 class="block__title">
+                <a class="block__link" href="https://docs.mongodb.com/database-tools/mongotop"><tt>mongotop</tt></a>
+              </h4>
+              <p class="block__body">Tracks the amount of time a <tt>mongod</tt> instance spends reading and writing data.</p>
+              <h4 class="block__title">
+                <a class="block__link" href="https://docs.mongodb.com/database-tools/mongofiles"><tt>mongofiles</tt></a>
+              </h4>
+              <p class="block__body">Read, write, delete, or update files in GridFS</p>
+              <h4 class="block__title">
+                <a class="block__link" href="https://docs.mongodb.com/database-tools/bsondump"><tt>bsondump</tt></a>
+              </h4>
+              <p class="block__body">Display BSON files in a human-readable format.</p class="block__body">
+            </div>
+          </div>
+          <div class="col-3 no-right-gutter">
+            <div class="block">
+              <h3 class="block__header">MongoDB Enterprise Kubernetes Operator</h3>
+              <h4 class="block__title">
+                <a class="block__link" href="https://docs.mongodb.com/kubernetes-operator/stable/installation/">Installation</a>
+              </h4>
+              <p class="block__body">Follow this tutorial to install the Kubernetes Operator.</p>
+              <h4 class="block__title">
+                <a class="block__link" href="https://docs.mongodb.com/kubernetes-operator/stable/tutorial/edit-deployment/">Configuration</a>
+              </h4>
+              <p class="block__body">Link the Kubernetes Operator to your Cloud Manager or Ops Manager Project.</p>
+              <h4 class="block__title">
+                <a class="block__link" href="https://docs.mongodb.com/kubernetes-operator/stable/deploy/">Resource Deployment</a>
+              </h4>
+              <p class="block__body">Deploy MongoDB standalone, replica set, and sharded cluster resources.</p>
+            </div>
           </div>
         </div>
 
-        <div class="col-3 no-right-gutter">
+        </div>
+
+      <div class="row">
+
+        <div class="col-3 no-left-gutter">
           <div class="block">
             <h3 class="block__header">MongoDB Spark Connector</h3>
             <h4 class="block__title">
@@ -254,7 +307,7 @@
         </div>
 
       </div>
-
+    </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adding https://docs.mongodb.com/database-tools to the list of available 'Tools' properties.

Built this locally and it looked OK to me. LMK if any other changes are required.