### PR TITLE
(DOCSP-10690): Add Community Operator to menu/landing page

### DIFF
--- a/src/html/home.html
+++ b/src/html/home.html
@@ -59,6 +59,11 @@
                <a class="toc__link"
                href="https://docs.mongodb.com/mongocli/stable/">MongoDB Command Line Interface</a>
              </li>
+             <li class="toc__item">
+              <a class="toc__link"
+              href="https://github.com/mongodb/mongodb-kubernetes-operator">MongoDB
+              Community Kubernetes Operator</a>
+            </li>
               <li class="toc__item">
                 <a class="toc__link" href="https://docs.mongodb.com/compass/current/">MongoDB Compass</a>
               </li>

--- a/src/html/tools.html
+++ b/src/html/tools.html
@@ -380,6 +380,9 @@
           </div>
         </div>
 
+       </div>
+
+       <div class="row">
         <div class="col-3 no-left-gutter">
          <div class="block">
            <h3 class="block__header">MongoDB Shell</h3>
@@ -395,8 +398,6 @@
          </div>
        </div>
 
-      </div>
-      <div class="row">
          <div class="col-3 no-left-gutter">
           <div class="block">
             <h3 class="block__header">MongoDB Spark Connector</h3>
@@ -415,6 +416,9 @@
           </div>
          </div>
 
+        </div>
+
+        <div class="row">
          <div class="col-3 no-left-gutter">
           <div class="block">
             <h3 class="block__header">MongoDB for VS Code</h3>
@@ -429,7 +433,9 @@
             </h4>
           </div>
         </div>
-      </div>
+        
+       </div>
+
     </div>
     </div>
   </div>

--- a/src/html/tools.html
+++ b/src/html/tools.html
@@ -19,6 +19,11 @@
            <a class="toc__link"
            href="https://docs.mongodb.com/mongocli/stable/">MongoDB Command Line Interface</a>
          </li>
+         <li class="toc__item">
+          <a class="toc__link"
+          href="https://github.com/mongodb/mongodb-kubernetes-operator">MongoDB
+          Community Kubernetes Operator</a>
+        </li>
           <li class="toc__item">
             <a class="toc__link" href="https://docs.mongodb.com/compass/current/">MongoDB Compass</a>
           </li>
@@ -30,7 +35,8 @@
             <a class="toc__link" href="https://docs.mongodb.com/kafka-connector/current/">MongoDB Kafka Connector</a>
           </li>
           <li class="toc__item">
-            <a class="toc__link" href="https://docs.mongodb.com/kubernetes-operator/stable/">MongoDB Kubernetes Operator</a>
+            <a class="toc__link"
+            href="https://docs.mongodb.com/kubernetes-operator/stable/">MongoDB Enterprise Kubernetes Operator</a>
           </li>
           <li class="toc__item">
            <a class="toc__link" href="https://docs.mongodb.com/mongodb-shell/">MongoDB Shell</a>
@@ -92,6 +98,14 @@
        </p>
      </a>
 
+     <a class="card" href="https://docs.mongodb.com/mongocli/stable/">
+      <span class="card__icon card__icon--document"></span>
+      <h3 class="card__title">MongoDB Community Kubernetes Operator</h3>
+      <p class="card__body">
+       Learn how you can use the Kubernetes Operator to run MongoDB Community on Kubernetes.
+      </p>
+    </a>
+
       <a class="card" href="https://docs.mongodb.com/compass/current/">
         <span class="card__icon card__icon--document"></span>
         <h3 class="card__title">MongoDB Compass</h3>
@@ -122,7 +136,7 @@
 
       <a class="card" href="https://docs.mongodb.com/kubernetes-operator/stable/">
         <span class="card__icon card__icon--document"></span>
-        <h3 class="card__title">MongoDB Kubernetes Operator</h3>
+        <h3 class="card__title">MongoDB Enterprise Kubernetes Operator</h3>
         <p class="card__body">
           Learn how you can use the Kubernetes Operator to run MongoDB Enterprise
           on Kubernetes and configure Cloud or Ops Manager for backup and monitoring.
@@ -257,6 +271,26 @@
 
       <div class="row">
 
+        <div class="col-3 no-left-gutter">
+          <div class="block">
+            <h3 class="block__header">MongoDB Community Kubernetes Operator</h3>
+            <h4 class="block__title">
+              <a class="block__link" href="https://github.com/mongodb/mongodb-kubernetes-operator/blob/master/README.md">Readme</a>
+            </h4>
+            <p class="block__body">Install or upgrade the Community Kubernetes Operator and deploy MongoDB resources.</p>
+            <h4 class="block__title">
+              <a class="block__link" href="https://github.com/mongodb/mongodb-kubernetes-operator/blob/master/architecture.md">Architecture</a>
+            </h4>
+            <p class="block__body">Learn about the technical details of
+            the Community Kubernetes Operator.</p>
+            <h4 class="block__title">
+              <a class="block__link" href="https://github.com/mongodb/mongodb-kubernetes-operator/blob/master/contributing.md">Contribute</a>
+            </h4>
+            <p class="block__body">Set up your environment to easily
+            contribute to the Community Kubernetes Operator.</p>
+          </div>
+        </div>
+
        <div class="col-3 no-left-gutter">
         <div class="block">
           <h3 class="block__header">MongoDB Compass</h3>
@@ -287,6 +321,9 @@
         </div>
       </div>
 
+     </div>
+
+     <div class="row">  
       <div class="col-3 no-left-gutter">
         <div class="block">
           <h3 class="block__header">MongoDB Database Tools</h3>
@@ -324,10 +361,7 @@
           <p class="block__body">Display BSON files in a human-readable format.</p class="block__body">
         </div>
       </div>
-
-      </div>
-
-      <div class="row">
+ 
         <div class="col-3 no-left-gutter">
           <div class="block">
             <h3 class="block__header">MongoDB Enterprise Kubernetes Operator</h3>


### PR DESCRIPTION
[Stage](https://docs-mongodborg-staging.corp.mongodb.com/landing/melissamahoney/DOCSP-10690/tools/index.html)

Adding the MongoDB Community Kubernetes Operator. Also renamed the existing "MongoDB Kubernetes Operator" to "MongoDB Enterprise Kubernetes Operator".