### PR TITLE
DOP-1337 Add search page with search-results directive

### DIFF
--- a/source/search.txt
+++ b/source/search.txt
@@ -1,1 +1,3 @@
+:template: blank
+
 .. search-results::

--- a/source/search.txt
+++ b/source/search.txt
@@ -1,3 +1,3 @@
-:template: blank
+:template: blank-wide
 
 .. search-results::

--- a/source/search.txt
+++ b/source/search.txt
@@ -1,3 +1,3 @@
-:template: blank-wide
+:template: blank
 
 .. search-results::

--- a/source/search.txt
+++ b/source/search.txt
@@ -1,0 +1,1 @@
+.. search-results::


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOP-1337)
[Spec](https://docs.google.com/document/d/10TAxNOdWDp_vi-D_NTnA_YDQXLeyoPsFa2Banx1Srsw/edit#heading=h.pyglchaeju4o)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/landing/docsworker-xlarge/DOP-1337/search)
[Job](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=5f36e7cc2f9a5cfb5b242c80)

This PR adds a new page at `/search` which simply invokes the new `search-results` directive to prepare for the new search UI.

This should not be merged until we are ready for the new Searchbar. Specifically we will also have to merge/deploy:
- [docs-tools #448](https://github.com/mongodb/docs-tools/pull/448)
- A forthcoming Snooty front-end branch `search-ui`