### PR TITLE
DOP-909: Add legacy page

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -7,9 +7,11 @@ version = 4.0
 package-name-org = "docs-landing"
 pgp-version = "{+version+}"
 
-# Non-snooty compatible docs are omitted
 [deprecated_versions]
-bi-connector = ["v1.1", "v2.0", "v2.1", "v2.2", "2.3"]
-manual = ["v2.2", "v2.4", "v2.6", "v3.0", "v3.2", "v3.4"]
-mms = ["v1.1", "v1.2", "v1.3"]
-spark-connector = ["v1.1", "v2.0"]
+bi-connector = ["v2.4", "v2.3", "v2.2", "v2.1", "v2.0", "v1.1"]
+kubernetes-operator = ["v0.12", "v0.11", "v0.10", "v0.9", "v0.8"]
+manual = ["v3.4", "v3.2", "v3.0", "v2.6", "v2.4", "v2.2"]
+mms = ["v3.6", "v3.4", "v2.0", "v1.8", "v1.6", "v1.5", "v1.4", "v1.3", "v1.2", "v1.1"]
+mongocli = ["v0.5.0", "v0.2.0", "v0.1.0", "v0.0.4", "v0.0.3"]
+ruby-driver = ["v2.3", "v2.2", "v2.0", "v1.x"]
+spark-connector = ["v2.0", "v1.1"]

--- a/snooty.toml
+++ b/snooty.toml
@@ -8,7 +8,7 @@ package-name-org = "docs-landing"
 pgp-version = "{+version+}"
 
 [deprecated_versions]
-bi-connector = ["v2.4", "v2.3", "v2.2", "v2.1", "v2.0", "v1.1"]
+bi-connector = ["v2.9", "v2.8", "v2.7", "v2.6", "v2.5", "v2.4", "v2.3", "v2.2", "v2.1", "v2.0", "v1.1"]
 kubernetes-operator = ["v0.12", "v0.11", "v0.10", "v0.9", "v0.8"]
 manual = ["v3.4", "v3.2", "v3.0", "v2.6", "v2.4", "v2.2"]
 mms = ["v3.6", "v3.4", "v2.0", "v1.8", "v1.6", "v1.5", "v1.4", "v1.3", "v1.2", "v1.1"]

--- a/source/legacy.txt
+++ b/source/legacy.txt
@@ -1,0 +1,14 @@
+:template: blank
+
+====================
+Legacy Documentation
+====================
+
+MongoDB encourages upgrading to the most recent version to ensure 
+documentation support. If upgrading is not possible, archived 
+documentation is still available for previous versions. Archived 
+documentation no longer receives updates.
+
+----------
+
+.. deprecated-version-selector::


### PR DESCRIPTION
[[JIRA](https://jira.mongodb.org/browse/DOP-909)] [[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/landing/docsworker-xlarge/DOP-909/legacy)] Add page at https://docs.mongodb.com/legacy to link to deprecated documentation. At the moment, nothing in Docs links to this page, so it will effectively be in stealth mode until some documentation is deprecated.

@jdestefano-mongo I added you as a reviewer in order to verify that we've included the correct versions for each product in the dropdown. I used [this spreadsheet](https://docs.google.com/spreadsheets/d/1AVS8NdMecph_xfmr44lI_zwHoowQfpgG6AJkSlx9e2w/edit#gid=794571501) as a reference and omitted the docs not hosted on docs.mongodb.com (drivers). Appreciate your help in advance—let me know if I can clarify anything!