### PR TITLE
DOP-banner: remove hard-coded banner

### DIFF
--- a/static/js/navbar.js
+++ b/static/js/navbar.js
@@ -180,10 +180,6 @@ class Navbar extends preact.Component {
 
         return (
             <div style="position: fixed; top: 0;">
-                <a href="https://www.mongodb.com/world">
-                    <img className="show-medium-and-up" src="https://docs.mongodb.com/images/mongodb-live-banner.png"  alt="Register Now for MongoDB.live, free & fully virtual on June 9th-10th" />
-                    <img className="hide-medium-and-up" src="https://docs.mongodb.com/images/mongodb-live-banner-mobile.png" alt="Register Now for MongoDB.live, free & fully virtual on June 9th-10th" />
-                </a>
                 <nav className="navbar">
                     <div className="navbar__left">
                         <a href="https://www.mongodb.com/">


### PR DESCRIPTION
Remove lingering hardcode of MongoDB World banner.

[landing1](https://docs-mongodbcom-staging.corp.mongodb.com/8fa72c7/landing/docsworker-xlarge/test-2/tools/)
[landing2](https://docs-mongodbcom-staging.corp.mongodb.com/d95e04e/landing/docsworker-xlarge/test-build/cloud/)