### PR TITLE
Remove Atlas OSB from sitemap index

### DIFF
--- a/static/sitemap-index.xml
+++ b/static/sitemap-index.xml
@@ -4,9 +4,6 @@
       <loc>https://docs.atlas.mongodb.com/sitemap.xml</loc>
     </sitemap>
     <sitemap>
-      <loc>https://docs.mongodb.com/atlas-open-service-broker/sitemap.xml</loc>
-    </sitemap>
-    <sitemap>
       <loc>https://docs.mongodb.com/bi-connector/current/sitemap.xml</loc>
     </sitemap>
     <sitemap>


### PR DESCRIPTION
Atlas OSB is deprecated so we don't want Google to find it, I think!