### PR TITLE
DOP-2215: Remove default_domain

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,6 +1,5 @@
 name = "landing"
 title = "MongoDB Documentation"
-default_domain = "landing"
 
 [constants]
 version = 4.0

--- a/source/index.txt
+++ b/source/index.txt
@@ -16,6 +16,7 @@ Welcome to the MongoDB Documentation
 
 .. card-group::
    :columns: 3
+   :layout: carousel
 
    .. card::
       :headline: Run a self-managed database
@@ -103,6 +104,7 @@ Community.
 
 .. card-group::
    :columns: 2
+   :layout: carousel
 
    .. card::
       :headline: Free Online Courses on MongoDB University


### PR DESCRIPTION
[DOP-2215](https://jira.mongodb.org/browse/DOP-2215).
[snooty-parser](https://github.com/mongodb/snooty-parser/pull/314).