### PR TITLE
DOP-2215: Remove default_domain

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,6 +1,5 @@
 name = "landing"
 title = "MongoDB Documentation"
-default_domain = "landing"
 
 [constants]
 version = 4.0


### PR DESCRIPTION
[DOP-2215](https://jira.mongodb.org/browse/DOP-2215).
[snooty-parser](https://github.com/mongodb/snooty-parser/pull/314).