### PR TITLE
DOP-2471: redirect legacy tools/cloud landing pages

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,0 +1,5 @@
+define: base https://docs.mongodb.com
+define: versions master
+
+temporary [master]: /tools -> ${base}/view-analyze/
+temporary [master]: /cloud -> ${base}/launch-manage/


### PR DESCRIPTION
I don't want these to be 301s since it seems entirely plausible we'll end up with a docs.mongodb.com/tools or mongodb.com/docs/tools/ again at some point and it would be tragic to have pre-emptively broken that (hence the temporary).