### PR TITLE
(DOCSP-20845):  Deprecate AOSB and move to Legacy Docs site

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -14,4 +14,4 @@ mms = ["v4.2", "v4.0", "v3.6", "v3.4", "v2.0", "v1.8", "v1.6", "v1.5", "v1.4", "
 mongocli = ["v0.5.0", "v0.2.0", "v0.1.0", "v0.0.4", "v0.0.3"]
 ruby-driver = ["v2.3", "v2.2", "v2.0", "v1.x"]
 spark-connector = ["v2.0", "v1.1"]
-cloud-docs-osb = ["master"]
+atlas-open-service-broker = ["master"]

--- a/snooty.toml
+++ b/snooty.toml
@@ -14,3 +14,4 @@ mms = ["v4.2", "v4.0", "v3.6", "v3.4", "v2.0", "v1.8", "v1.6", "v1.5", "v1.4", "
 mongocli = ["v0.5.0", "v0.2.0", "v0.1.0", "v0.0.4", "v0.0.3"]
 ruby-driver = ["v2.3", "v2.2", "v2.0", "v1.x"]
 spark-connector = ["v2.0", "v1.1"]
+cloud-docs-osb = ["master"]


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-20845)
[Clean build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=629a5aaa7cf5397525b634a9)

This PR adds the Atlas Open Service Broker to the Legacy Docs product menu.
To be completed with https://github.com/10gen/cloud-docs-osb/pull/27