### PR TITLE
Remove legacy mongo shell reference from the landing page.

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -97,7 +97,7 @@ Learn through examples and best practices
 Zoe works at a university that uses MongoDB to store student records.
 Since her background is in SQL, Zoe reads the
 :manual:`MongoDB Manual </>` to learn how to build queries using the
-``mongo`` shell. 
+MongoDB Shell.
 
 .. cta::
 


### PR DESCRIPTION
Staging: https://docs-mongodbcom-staging.corp.mongodb.com/landing/docsworker-xlarge/shell-fix/