### PR TITLE
DOP-3427: Add preview option to openapi preview page

### DIFF
--- a/source/openapi/preview.txt
+++ b/source/openapi/preview.txt
@@ -14,3 +14,4 @@
    This page is intended for previewing OpenAPI spec files with the styling of MongoDB's documentation. The contents may not reflect actual endpoints or services.
 
 .. openapi:: /openapi/loremipsum.json
+   :preview:


### PR DESCRIPTION
### Ticket

[DOP-3427](https://jira.mongodb.org/browse/DOP-3427)

### Current Behavior

[OpenAPI preview page](https://www.mongodb.com/docs/openapi/preview/) - should be built with client-side rendering

### Staging

[OpenAPI preview page](https://docs-mongodb-org-dotcomstg.s3.us-east-2.amazonaws.com/landing/docsworker-xlarge/DOP-3427-origin/openapi/preview/index.html) - should be built with client-side rendering; built using Autobuilder's pre-prd staging webhook

### Notes

* Adds `preview` option to `openapi` directive. This will flag to the parser to not build OpenAPI metadata for this page to allow the frontend to render this page client-side (as opposed to statically).
* Tested this option locally using the Autobuilder's OpenAPI Page Builder module and using the Autobuilder's pre-prd staging webhook ([build log](https://workerpoolstaging-qgeyp.mongodbstitch.com/pages/job.html?collName=dotcom_queue&jobId=63b59ad7dc742b91f2b82ffe)), yielding the following output:
```
No OpenAPI content pages found.
Finished building OpenAPI content pages.
```
* This PR should be merged anytime prior to merging https://github.com/mongodb/docs-worker-pool/pull/723 to avoid loss in preview functionality