### PR TITLE
DOP-3455: Update base url for redirects

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,5 +1,6 @@
-define: base https://docs.mongodb.com
+define: prefix docs
+define: base https://www.mongodb.com/${prefix}
 define: versions master
 
-temporary [master]: /tools -> ${base}/view-analyze/
-temporary [master]: /cloud -> ${base}/launch-manage/
+temporary [master]: ${prefix}/tools -> ${base}/view-analyze/
+temporary [master]: ${prefix}/cloud -> ${base}/launch-manage/

--- a/config/redirects
+++ b/config/redirects
@@ -2,5 +2,5 @@ define: prefix docs
 define: base https://www.mongodb.com/${prefix}
 define: versions master
 
-temporary [master]: ${prefix}/tools -> ${base}/view-analyze/
-temporary [master]: ${prefix}/cloud -> ${base}/launch-manage/
+raw: ${prefix}/tools -> ${base}/view-analyze/
+raw: ${prefix}/cloud -> ${base}/launch-manage/


### PR DESCRIPTION
### Ticket

[DOP-3455](https://jira.mongodb.org/browse/DOP-3455)

### Notes

* No content change, so no staging link for now.
* Will perform a `/deploy` after merging and check to ensure that the following URLs are redirected properly:
   * https://mongodb.com/docs/tools -> https://mongodb.com/docs/view-analyze/
   * https://mongodb.com/docs/cloud -> https://mongodb.com/docs/launch-manage/