### PR TITLE
(DOCSP-30244): Add Kotlin to landing page card

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -64,7 +64,7 @@ Welcome to the MongoDB Documentation
       :icon-alt: Drivers icon
 
       Connect your application via MongoDB client libraries for Python,
-      Javascript, Typescript, Java, C#, Ruby, PHP, Go, and Rust.
+      Javascript, Typescript, Java, C#, Ruby, PHP, Go, Rust, and Kotlin.
 
    .. card::
       :headline: Tools and Connectors


### PR DESCRIPTION
Add Kotlin to list of drivers on landing page

To be merged and deployed next Wed (June 21) in preparation for NYC.local, if possible.

[Jira](https://jira.mongodb.org/browse/DOCSP-30244)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/landing/docsworker-xlarge/docsp-30244/)