### PR TITLE
DOCSP-30859-eol-kafka-v1.0-v1.7

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -17,3 +17,4 @@ ruby-driver = ["v2.15", "v2.14", "v2.13", "v2.12", "v2.11", "v2.10", "v2.9", "v2
 spark-connector = ["v2.0", "v1.1"]
 atlas-open-service-broker = ["master"]
 node = ["v3.6", "v3.7", "v4.0", "v4.1", "v4.2", "v4.3", "v4.4", "v4.5", "v4.6", "v4.7"]
+kafka-connector = ["v1.0", "v1.1", "v1.2", "v1.3", "v1.4", "v1.5", "v1.6", "v1.7"]


### PR DESCRIPTION
[DOCSP-30859](https://jira.mongodb.org/browse/DOCSP-30859)
adding EOL versions of kafka connector to snooty.toml