### PR TITLE
DOCSP-33640: link to new rust docs

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -151,7 +151,7 @@ MongoDB Documentation
 
    .. card::
       :headline: Rust
-      :url: https://www.mongodb.com/docs/drivers/rust/
+      :url: https://www.mongodb.com/docs/drivers/rust/current/
       :icon: /images/icons/rust.svg
       :icon-alt: Rust Driver icon
 


### PR DESCRIPTION
https://preview-mongodbrustagir.gatsbyjs.io/landing/DOCSP-33640-rust-new-docs/

the rust link 404s, but the link should be correct