### PR TITLE
Rename "Realm" to "Atlas Device SDK"

### DIFF
--- a/source/develop-applications.txt
+++ b/source/develop-applications.txt
@@ -26,7 +26,7 @@ Develop Applications
       :project-name: app-services
       :primary:
       
-   .. entry:: Realm SDKs
+   .. entry:: Atlas Device SDK
       :url: https://www.mongodb.com/docs/realm/
       :project-name: realm
       :primary:


### PR DESCRIPTION
Realm has been rebranded to Atlas Device SDK. We updated other parts of the docs, but this page slipped through the cracks. Related to the work in this Jira ticket: https://jira.mongodb.org/browse/DOCSP-37609