### PR TITLE
(DOCSP-37691) Adjust Migrators, Tools & Connectors TOC to point to section headings

### DIFF
--- a/source/tools-and-connectors.txt
+++ b/source/tools-and-connectors.txt
@@ -6,62 +6,24 @@ Migrators, Tools, and Connectors
 
 .. ia::
 
-   .. entry:: Relational Migrator
-      :url: https://www.mongodb.com/docs/relational-migrator/
-      :primary:
+   .. entry:: Generative AI Information
+      :url: https://www.mongodb.com/docs/tools-and-connectors/#generative-ai-information
 
-   .. entry:: Atlas Live Migration
-      :url: https://www.mongodb.com/docs/atlas/import/
+   .. entry:: Migrators
+      :url: https://www.mongodb.com/docs/tools-and-connectors/#migrators
 
-   .. entry:: Cluster-to-Cluster Sync
-      :url: https://www.mongodb.com/docs/cluster-to-cluster-sync/current/connecting/onprem-to-atlas/
+   .. entry:: Data Exploration and Visualization
+      :url: https://www.mongodb.com/docs/tools-and-connectors/#data-exploration-and-visualization
    
-   .. entry:: Database Tools
-      :url: https://www.mongodb.com/docs/database-tools/
+   .. entry:: IDE Integrations
+      :url: https://www.mongodb.com/docs/tools-and-connectors/#ide-integrations
 
-   .. entry:: Compass
-      :url: https://www.mongodb.com/docs/compass/current/
-      :project-name: compass
+   .. entry:: Connectors
+      :url: https://www.mongodb.com/docs/tools-and-connectors/#connectors
    
-   .. entry:: Charts
-      :url: https://www.mongodb.com/docs/charts/
-      :project-name: charts
-   
-   .. entry:: MongoDB for VS Code
-      :url: https://www.mongodb.com/docs/mongodb-vscode/
-      :project-name: mongodb-vscode
-
-   .. entry:: MongoDB Analyzer
-      :url: https://www.mongodb.com/docs/mongodb-analyzer/current/
-      :project-name: mongodb-analyzer
-   
-   .. entry:: BI Connector
-      :url: https://www.mongodb.com/docs/bi-connector/current/
-      :project-name: bi-connector
-
-   .. entry:: Kafka Connector
-      :url: https://docs.mongodb.com/kafka-connector/current/
-      :project-name: kafka-connector   
-
-   .. entry:: Spark Connector
-      :url: https://www.mongodb.com/docs/spark-connector/current/
-      :project-name: spark-connector
-
-   .. entry:: Atlas SQL
-      :url: https://www.mongodb.com/docs/atlas/data-federation/query/query-with-sql/
-      :project-name: atlas-sql
-
-   .. entry:: Cloud Manager
-      :url: https://www.mongodb.com/docs/cloud-manager
-
-   .. entry:: Ops Manager
-      :url: https://www.mongodb.com/docs/ops-manager/current/
-
-   .. entry:: MongoDB Kubernetes Operators
-      :url: https://www.mongodb.com/docs/kubernetes-operator/stable/
-
-   .. entry:: PyMongoArrow
-      :url: https://mongo-arrow.readthedocs.io/en/stable/ 
+   .. entry:: Management Tools
+      :url: https://www.mongodb.com/docs/tools-and-connectors/#management-tools
+      
 
 Generative AI Information
 -------------------------

--- a/source/tools-and-connectors.txt
+++ b/source/tools-and-connectors.txt
@@ -6,9 +6,6 @@ Migrators, Tools, and Connectors
 
 .. ia::
 
-   .. entry:: Generative AI Information
-      :url: https://www.mongodb.com/docs/tools-and-connectors/#generative-ai-information
-
    .. entry:: Migrators
       :url: https://www.mongodb.com/docs/tools-and-connectors/#migrators
 
@@ -23,23 +20,10 @@ Migrators, Tools, and Connectors
    
    .. entry:: Management Tools
       :url: https://www.mongodb.com/docs/tools-and-connectors/#management-tools
+
+   .. entry:: Generative AI Information
+      :url: https://www.mongodb.com/docs/tools-and-connectors/#generative-ai-information
       
-
-Generative AI Information
--------------------------
-
-.. card-group::
-   :columns: 2
-   :style: extra-compact
-
-   .. card::
-      :headline: Generative AI FAQs
-      :url: https://www.mongodb.com/docs/generative-ai-faq/
-      :icon: /images/icons/mongodb-dna.png
-      :icon-alt: Gen AI alt
-
-      Learn how MongoDB applications can enhance your user experience 
-      by using generative AI.
 
 Migrators
 ---------
@@ -216,3 +200,19 @@ Management Tools
       :icon-alt: Kubernetes Operator LogoMark
 
       Learn how to run MongoDB in Kubernetes on your own infrastructure.
+
+Generative AI Information
+-------------------------
+
+.. card-group::
+   :columns: 2
+   :style: extra-compact
+
+   .. card::
+      :headline: Generative AI FAQs
+      :url: https://www.mongodb.com/docs/generative-ai-faq/
+      :icon: /images/icons/mongodb-dna.png
+      :icon-alt: Gen AI alt
+
+      Learn how MongoDB applications can enhance your user experience 
+      by using generative AI.


### PR DESCRIPTION
[Staging](https://preview-mongodbmelissamahoneymongodb.gatsbyjs.io/landing/DOCSP-37691/tools-and-connectors/)

This PR:
* Removes individual products from the left nav on the Migrators, Tools, and Connectors landing page
* Creates TOC entries that point to the section headings on the page
* Moves the Gen AI FAQs to the bottom of the page

[Clean build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65f1f8eb6fc5f0485031648c)