### PR TITLE
DOP-4543: Generalize bottom cards to use large-icon style

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -174,22 +174,20 @@ More Ways to Learn
 
 .. card-group::
    :columns: 3
+   :style: large-icon
    :layout: default
 
    .. card::
       :icon: /images/general-content-learn.svg
       :headline: Take Free Courses on MongoDB University
-      :tag: landing-bottom
       :url: https://learn.mongodb.com/
    
    .. card::
       :icon: /images/general-content-community.svg
       :headline: Join Forums and Discussions
-      :tag: landing-bottom
       :url: https://www.mongodb.com/community/
    
    .. card::
       :icon: /images/technical-mdb-devhub.svg
       :headline: View Developer Resources
-      :tag: landing-bottom
       :url: https://www.mongodb.com/developer/


### PR DESCRIPTION
This rST change is an attempt to have the bottom cards use a general style option that should be reusable for the programming language landing pages.

**This PR should be merged AFTER releasing the [frontend](https://github.com/mongodb/snooty/pull/1062) and [parser](https://github.com/mongodb/snooty-parser/pull/584) PRs.**

[Staging link](https://docs-mongodb-org-stg.s3.us-east-2.amazonaws.com/DOP-4543-generalize-cards/landing/raymund.rodriguez/main/index.html#more-ways-to-learn)
[Prod link](https://www.mongodb.com/docs/#more-ways-to-learn)

[Related PR comment](https://github.com/mongodb/snooty/pull/1062#issuecomment-2052432691).