### PR TITLE
(DOCSP-44171) [Docs-Landing] Removed Yii framework from PHP landing page.

### DIFF
--- a/source/languages/php.txt
+++ b/source/languages/php.txt
@@ -69,12 +69,6 @@ retrieve objects, or use MongoDB as a data store.
       :url: https://www.mongodb.com/docs/drivers/php-frameworks/symfony/
       :icon: /languages/images/symfony.png
       :icon-alt: Symfony logo
-  
-   .. card::
-      :headline: Yii Framework
-      :url: https://www.yiiframework.com/extension/yiisoft/yii2-mongodb
-      :icon: /languages/images/yii.png
-      :icon-alt: Yii logo
 
 Integrations
 ------------

--- a/source/launch-manage.txt
+++ b/source/launch-manage.txt
@@ -95,7 +95,7 @@ your self-managed databases.
    .. card::
       :headline: MongoDB Kubernetes Operators
       :url: https://www.mongodb.com/docs/kubernetes-operator/stable/
-      :icon:connectors_kubernetes_operator
+      :icon: connectors_kubernetes_operator
       :icon-alt: Kubernetes Operator LogoMark
 
       Learn how to run MongoDB in Kubernetes on your own infrastructure.


### PR DESCRIPTION
 Removed Yii framework from PHP landing page. 
 
 - [DOCSP-44171](https://jira.mongodb.org/browse/DOCSP-44171)
 - [STAGING](https://deploy-preview-214--docs-landing-mongodb.netlify.app/languages/php/)