### PR TITLE
DOCSP-45635-intellij-docs-landing

### DIFF
--- a/source/tools-and-connectors.txt
+++ b/source/tools-and-connectors.txt
@@ -123,6 +123,15 @@ IDE Integrations
       Understand and troubleshoot queries and aggregations directly inside
       Visual Studio and other tools.
 
+   .. card::
+      :headline: IntelliJ Plugin 
+      :url: https://www.mongodb.com/docs/mongodb-intellij/
+      :icon: mdb_shell
+      :icon-alt: IntelliJ Plugin LogoMark
+
+      Build applications and work with your MongoDB data directly from 
+      IntelliJ IDEA.
+
 Connectors
 ----------
 


### PR DESCRIPTION
## HOLD OFF ON MERGING UNTIL GA
Changes from #220, which adds IntelliJ to the Migrators, Tools, and Connectors docs home page.

## STAGING
https://deploy-preview-222--docs-landing-mongodb.netlify.app/tools-and-connectors/#ide-integrations

## JIRA
https://jira.mongodb.org/browse/DOCSP-45635