### PR TITLE
Add missing meta descriptions

### DIFF
--- a/source/generative-ai-faq.txt
+++ b/source/generative-ai-faq.txt
@@ -8,6 +8,9 @@
 Generative AI FAQs
 ==================
 
+.. meta::
+   :description: Explore MongoDB's generative AI features, including query generation and visualization, powered by Azure OpenAI and Github Copilot.
+
 .. image:: /images/homepage-hero.svg
    :class: hero-img
    :alt: Homepage illustration

--- a/source/languages/c.txt
+++ b/source/languages/c.txt
@@ -7,6 +7,9 @@
 MongoDB with C
 ==============
 
+.. meta::
+   :description: Explore building applications with MongoDB's C driver, utilizing `libbson` and `libmongoc` for BSON document handling and database connectivity.
+
 .. include:: /includes/docs-toc.rst
    
 .. introduction::

--- a/source/languages/cpp.txt
+++ b/source/languages/cpp.txt
@@ -6,6 +6,9 @@
 MongoDB with C++
 ================
 
+.. meta::
+   :description: Explore using MongoDB's C++ driver to build applications like engines, games, and GUIs with Atlas cloud database support.
+
 .. include:: /includes/docs-toc.rst
 
 .. introduction::

--- a/source/languages/csharp.txt
+++ b/source/languages/csharp.txt
@@ -6,6 +6,9 @@
 MongoDB with C#
 ===============
 
+.. meta::
+   :description: Explore using C# with MongoDB, including the .NET/C# driver, Entity Framework integration, and various libraries and extensions for application development.
+
 .. include:: /includes/docs-toc.rst
    
 .. introduction::

--- a/source/languages/go.txt
+++ b/source/languages/go.txt
@@ -6,6 +6,9 @@
 MongoDB with Go
 ===============
 
+.. meta::
+   :description: Explore building Go applications with MongoDB's Atlas, utilizing OpenTelemetry and community integrations.
+
 .. include:: /includes/docs-toc.rst
    
 .. introduction::

--- a/source/languages/java.txt
+++ b/source/languages/java.txt
@@ -6,6 +6,9 @@
 MongoDB with Java
 =================
 
+.. meta::
+   :description: Develop Java applications using Atlas with synchronous and asynchronous drivers, and integrate with Spring Data MongoDB for scalable solutions.
+
 .. include:: /includes/docs-toc.rst
 
 .. introduction::

--- a/source/languages/javascript.txt
+++ b/source/languages/javascript.txt
@@ -6,6 +6,9 @@
 MongoDB with JavaScript
 =======================
 
+.. meta::
+   :description: Explore JavaScript and TypeScript integrations with MongoDB, including Node.js driver features and support for MERN and MEAN stack applications.
+
 .. include:: /includes/docs-toc.rst
 
 .. introduction::

--- a/source/languages/kotlin.txt
+++ b/source/languages/kotlin.txt
@@ -6,6 +6,9 @@
 MongoDB with Kotlin
 ===================
 
+.. meta::
+   :description: Develop server-side Kotlin applications using Atlas with coroutine-based and synchronous MongoDB drivers.
+
 .. include:: /includes/docs-toc.rst
 
 .. introduction::

--- a/source/languages/php.txt
+++ b/source/languages/php.txt
@@ -6,6 +6,9 @@
 MongoDB with PHP
 ================
 
+.. meta::
+   :description: Build PHP applications using Atlas, PHP drivers, and integrations with frameworks like Laravel and Symfony.
+
 .. include:: /includes/docs-toc.rst
 
 .. introduction::

--- a/source/languages/python.txt
+++ b/source/languages/python.txt
@@ -6,6 +6,9 @@
 MongoDB with Python
 ===================
 
+.. meta::
+   :description: Explore building applications with Python and MongoDB, utilizing drivers, frameworks, and libraries for robust and scalable solutions.
+
 .. include:: /includes/docs-toc.rst
 
 .. introduction::

--- a/source/languages/ruby.txt
+++ b/source/languages/ruby.txt
@@ -6,6 +6,9 @@
 MongoDB with Ruby
 =================
 
+.. meta::
+   :description: Explore how to integrate MongoDB with Ruby on Rails applications using Mongoid, leveraging conventions similar to Active Record for data modeling.
+
 .. include:: /includes/docs-toc.rst
    
 .. introduction::

--- a/source/languages/rust.txt
+++ b/source/languages/rust.txt
@@ -6,6 +6,9 @@
 MongoDB with Rust
 =================
 
+.. meta::
+   :description: Explore how to develop Rust applications with MongoDB's Atlas, using integrations like Rocket and Actix for enhanced performance and safety.
+
 .. include:: /includes/docs-toc.rst
    
 .. introduction::

--- a/source/languages/scala.txt
+++ b/source/languages/scala.txt
@@ -6,6 +6,9 @@
 MongoDB with Scala
 ==================
 
+.. meta::
+   :description: Explore resources for building high-performance applications with Scala using the MongoDB Atlas cloud database and Scala driver.
+
 .. include:: /includes/docs-toc.rst
 
 .. introduction::

--- a/source/tools-and-connectors.txt
+++ b/source/tools-and-connectors.txt
@@ -2,6 +2,9 @@
 Migrators, Tools, and Connectors
 ================================
 
+.. meta::
+   :description: Explore various tools and connectors for migrating, visualizing, and managing MongoDB data across different environments and platforms.
+
 .. ia::
 
    .. entry:: Migrators


### PR DESCRIPTION
Adds missing meta descriptions generated by the Education AI Team\n\nSOURCE: https://docs.google.com/spreadsheets/d/1fdrjF4Ms9fMl96zLiLGsYD_V38rTfPLuKs5VQk4vz6E/edit?gid=1166644539